### PR TITLE
[codex] show moderation confidence and all-region filter

### DIFF
--- a/frontend/e2e/owner-smoke.cjs
+++ b/frontend/e2e/owner-smoke.cjs
@@ -348,6 +348,20 @@ async function gotoOwnerWithStaleLocationStorage(page, url, type) {
   if (body.ip_addr !== "") {
     throw new Error(`Owner console defaulted to stale location filter: ${body.ip_addr}`);
   }
+  await assertAllRegionsLocationDefault(page, "Owner console");
+}
+
+async function assertAllRegionsLocationDefault(page, surface) {
+  const locationFilter = page.locator("#location_addr");
+  await locationFilter.waitFor({ timeout: 10_000 });
+  const defaultLocationLabel = await locationFilter.locator("option[value='']").textContent();
+  if ((defaultLocationLabel || "").trim() !== "所有地区") {
+    throw new Error(`${surface} location filter default option mismatch: ${defaultLocationLabel}`);
+  }
+  const selectedLocation = await locationFilter.inputValue();
+  if (selectedLocation !== "") {
+    throw new Error(`${surface} location filter defaulted to a concrete location: ${selectedLocation}`);
+  }
 }
 
 async function selectQuestionType(page, type) {
@@ -476,6 +490,7 @@ async function assertKeywordModerationReview(page, config, owner, type, ownerTok
   }
 
   await Promise.all([waitForOwnerList(page), page.getByRole("button", { name: /审核队列/ }).click()]);
+  await assertAllRegionsLocationDefault(page, "Empty review queue");
   if ((await page.getByText(text).count()) > 0) {
     throw new Error("Keyword-moderated submission leaked into review owner list");
   }
@@ -483,7 +498,7 @@ async function assertKeywordModerationReview(page, config, owner, type, ownerTok
   await page.goto(`${baseUrl}/#/question?token=${askerToken}`);
   await page.getByText(text).waitFor({ timeout: 10_000 });
 
-  return ["keyword moderation hidden from owner", "keyword moderation visible to asker"];
+  return ["keyword moderation hidden from owner", "empty review queue all regions", "keyword moderation visible to asker"];
 }
 
 async function assertSeededModerationReview(page, config, owner, type, ownerToken) {
@@ -494,10 +509,13 @@ async function assertSeededModerationReview(page, config, owner, type, ownerToke
 
   await gotoWithQuestionTypeStorage(page, `${baseUrl}/#/owner/${owner}/dashboard?token=${ownerToken}`, type);
   await Promise.all([waitForOwnerList(page), page.getByRole("button", { name: /审核队列/ }).click()]);
+  await assertAllRegionsLocationDefault(page, "Review queue");
 
   const approveCard = reviewCard(approveFixture);
   await approveCard.waitFor({ timeout: 10_000 });
-  await approveCard.getByText(approveFixture.short_reason, { exact: true }).waitFor({ timeout: 10_000 });
+  await approveCard
+    .getByText(`${approveFixture.short_reason}（置信度 98%）`, { exact: true })
+    .waitFor({ timeout: 10_000 });
   if ((await approveCard.getByText(approveFixture.text).count()) > 0) {
     throw new Error("Review queue displayed raw submission text");
   }
@@ -738,6 +756,7 @@ async function main() {
     const liveText = `live auto ${Date.now()}`;
     const liveToken = await submitViaApi(page.request, owner, type, liveText);
     await gotoWithQuestionTypeStorage(page, `${baseUrl}/#/owner/${owner}/live?token=${ownerToken}`, type);
+    await assertAllRegionsLocationDefault(page, "Live view");
     await page.getByText(liveText).waitFor({ timeout: 10_000 });
     await page.locator(".card.shadow-sm.my-2").filter({ hasText: liveText }).first().getByText("← 投屏").click();
     await page.locator("#textProjectArea").getByText(liveText).waitFor({ timeout: 10_000 });

--- a/frontend/src/components/LiveView.vue
+++ b/frontend/src/components/LiveView.vue
@@ -155,7 +155,7 @@
                       <option value="365">1年内</option>
                     </select>
                   </li>
-                  <li class="nav-item mx-1 my-1" v-if="locationOptions.length > 0">
+                  <li class="nav-item mx-1 my-1">
                     <select
                       class="form-select"
                       aria-label="location select"
@@ -163,7 +163,7 @@
                       v-on:change="onQueryChange(true)"
                       v-model="queryParams['ip_addr']"
                     >
-                      <option value="">全部地区</option>
+                      <option value="">所有地区</option>
                       <option
                         v-for="option in locationOptions"
                         v-bind:key="option.addr"

--- a/frontend/src/components/OwnerView.vue
+++ b/frontend/src/components/OwnerView.vue
@@ -56,7 +56,7 @@
                     <option value="365">1年内</option>
                   </select>
                 </li>
-                <li class="nav-item m-1 owner-filter-control" v-if="locationOptions.length > 0">
+                <li class="nav-item m-1 owner-filter-control">
                   <select
                     class="form-select"
                     aria-label="location select"
@@ -64,7 +64,7 @@
                     v-on:change="onQueryChange(true)"
                     v-model="queryParams['ip_addr']"
                   >
-                    <option value="">全部地区</option>
+                    <option value="">所有地区</option>
                     <option
                       v-for="option in locationOptions"
                       v-bind:key="option.addr"
@@ -663,8 +663,21 @@ export default {
     },
     moderationReviewSummary(q) {
       const moderation = q.moderation || {};
-      if (this.isChineseText(moderation.short_reason)) return moderation.short_reason;
-      return this.moderationChineseFallback(moderation);
+      const reason = this.isChineseText(moderation.short_reason)
+        ? moderation.short_reason
+        : this.moderationChineseFallback(moderation);
+      const confidence = this.moderationConfidenceText(moderation);
+      return confidence ? `${reason}（${confidence}）` : reason;
+    },
+    moderationConfidenceText(moderation) {
+      const rawConfidence = moderation.confidence;
+      if (rawConfidence === null || rawConfidence === undefined || rawConfidence === "") {
+        return "";
+      }
+      const confidence = Number(rawConfidence);
+      if (!Number.isFinite(confidence)) return "";
+      const percentage = confidence <= 1 ? confidence * 100 : confidence;
+      return `置信度 ${Math.round(percentage)}%`;
     },
     moderationChineseFallback(moderation) {
       const reasonLabels = {


### PR DESCRIPTION
## Summary

- Keep the geo location filter visible in owner dashboard and live view even when there are no concrete region options.
- Rename the empty location choice to 所有地区 and keep its submitted value as an empty string.
- Show moderation confidence next to the review queue short reason, for example 疑似骚扰或攻击内容（置信度 98%）.
- Extend owner smoke coverage for empty review queues, review queues with seeded moderation rows, live view location defaults, and confidence rendering.

## Validation

- cd frontend && npm run lint -- --max-warnings=0
- cd frontend && npm run build
- cd frontend && AQBOX_E2E_CONFIG=/private/tmp/aqbox-all-regions.yaml AQBOX_E2E_OWNER=owner AQBOX_E2E_TYPE=normal npm run e2e:smoke

Smoke output included empty review queue all regions and seeded moderation queue summary. Build still emits existing Sass deprecation / chunk size warnings.