### PR TITLE
[codex] raise LLM moderation token cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ __pycache__/
 *.egg-info/
 backend/config/
 test/*.db
+test/*.db-shm
+test/*.db-wal
+test/moderation_analysis/
 *.xdb

--- a/backend/aqbox/config.py
+++ b/backend/aqbox/config.py
@@ -136,7 +136,7 @@ class LLMModerationConfig:
     review_all_model_rejects: bool = True
     max_attempts: int = 2
     timeout_seconds: float = 10.0
-    max_tokens: int = 256
+    max_tokens: int = 10240
     initial_backoff_seconds: float = 1.0
     raw_retention_enabled: bool = False
     raw_retention_seconds: int = 0
@@ -242,7 +242,7 @@ def _parse_llm_moderation_config(raw: dict[str, Any]) -> LLMModerationConfig:
         ),
         max_attempts=max(1, _as_int(raw.get("max_attempts"), default=2)),
         timeout_seconds=max(0.1, _as_float(raw.get("timeout_seconds"), default=10.0)),
-        max_tokens=max(1, _as_int(raw.get("max_tokens"), default=256)),
+        max_tokens=max(1, _as_int(raw.get("max_tokens"), default=10240)),
         initial_backoff_seconds=max(0.0, _as_float(raw.get("initial_backoff_seconds"), default=1.0)),
         raw_retention_enabled=_as_bool(raw.get("raw_retention_enabled"), default=False, field_name="llm_filter.raw_retention_enabled"),
         raw_retention_seconds=max(0, _as_int(raw_retention_seconds, default=0)),

--- a/backend/tests/test_backend_contract.py
+++ b/backend/tests/test_backend_contract.py
@@ -1392,12 +1392,12 @@ def test_llm_moderation_config_requires_global_and_type_enablement(tmp_path: Pat
     assert loaded.llm_moderation.review_all_model_rejects is True
     assert loaded.llm_moderation.max_attempts == 2
     assert loaded.llm_moderation.timeout_seconds == 10.0
-    assert loaded.llm_moderation.max_tokens == 256
+    assert loaded.llm_moderation.max_tokens == 10240
     assert loaded.llm_moderation.initial_backoff_seconds == 1.0
     assert loaded.llm_moderation.raw_retention_enabled is False
     assert loaded.llm_moderation.raw_retention_seconds == 0
     assert enabled_policy.timeout_seconds == 10.0
-    assert enabled_policy.max_tokens == 256
+    assert enabled_policy.max_tokens == 10240
     assert enabled_policy.initial_backoff_seconds == 1.0
 
     monkeypatch.delenv("AQBOX_TEST_LLM_KEY")
@@ -1611,7 +1611,7 @@ def test_ops_config_redacts_llm_api_keys_from_env_and_config(tmp_path: Path, mon
     assert cfg.status_code == 200
     assert cfg.json()["llm_filter"]["api_key_configured"] is True
     assert cfg.json()["llm_filter"]["timeout_seconds"] == 10.0
-    assert cfg.json()["llm_filter"]["max_tokens"] == 256
+    assert cfg.json()["llm_filter"]["max_tokens"] == 10240
     assert cfg.json()["llm_filter"]["initial_backoff_seconds"] == 1.0
     assert cfg.json()["llm_filter"]["raw_retention_enabled"] is False
     assert cfg.json()["llm_filter"]["raw_retention_seconds"] == 0


### PR DESCRIPTION
## Summary
- Raise the default LLM moderation response token cap to 10240 so PRD prompts have enough room for structured moderation output.
- Update backend contract tests for the new default.
- Ignore local moderation analysis artifacts and SQLite sidecar files so historical eval data is not committed.

## Validation
- `uv run pytest backend/tests/test_backend_contract.py -q -k 'llm_moderation_config_requires_global_and_type_enablement or ops_config_redacts_llm_api_keys_from_env_and_config'`

## Production note
Production config was hot-reloaded separately and verified via `/ops/health` and `/ops/config`; no production test submissions were created.