### PR TITLE
[codex] Detach live projector window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ __pycache__/
 *.egg-info/
 backend/config/
 test/*.db
+test/*.db-shm
+test/*.db-wal
+test/moderation_analysis/
 *.xdb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,12 +75,11 @@ cd frontend
 AQBOX_E2E_CONFIG=../backend/config/config.local.yaml npm run e2e:smoke
 ```
 
-On macOS inside Codex, Playwright smoke may fail before app code runs with a Chromium
-MachPort/bootstrap permission error such as `bootstrap_check_in ... Permission denied`.
-Treat that as a sandbox launch issue, not an application regression: rerun the same
-`npm run e2e:smoke` command with escalated permissions. If the smoke temporarily
-disables paid LLM calls or mutates a preview config, restore that config immediately
-after the rerun.
+Inside Codex, do not run Playwright smoke/browser tests without escalated permissions.
+Chromium may fail before app code runs with a macOS MachPort/bootstrap permission error
+such as `bootstrap_check_in ... Permission denied`. If the smoke temporarily disables
+paid LLM calls or mutates a preview config, restore that config immediately after the
+rerun.
 
 When local geo is enabled and xdb paths are configured, include the optional geo assertions:
 

--- a/backend/aqbox/config.py
+++ b/backend/aqbox/config.py
@@ -136,7 +136,7 @@ class LLMModerationConfig:
     review_all_model_rejects: bool = True
     max_attempts: int = 2
     timeout_seconds: float = 10.0
-    max_tokens: int = 256
+    max_tokens: int = 10240
     initial_backoff_seconds: float = 1.0
     raw_retention_enabled: bool = False
     raw_retention_seconds: int = 0
@@ -242,7 +242,7 @@ def _parse_llm_moderation_config(raw: dict[str, Any]) -> LLMModerationConfig:
         ),
         max_attempts=max(1, _as_int(raw.get("max_attempts"), default=2)),
         timeout_seconds=max(0.1, _as_float(raw.get("timeout_seconds"), default=10.0)),
-        max_tokens=max(1, _as_int(raw.get("max_tokens"), default=256)),
+        max_tokens=max(1, _as_int(raw.get("max_tokens"), default=10240)),
         initial_backoff_seconds=max(0.0, _as_float(raw.get("initial_backoff_seconds"), default=1.0)),
         raw_retention_enabled=_as_bool(raw.get("raw_retention_enabled"), default=False, field_name="llm_filter.raw_retention_enabled"),
         raw_retention_seconds=max(0, _as_int(raw_retention_seconds, default=0)),

--- a/backend/tests/test_backend_contract.py
+++ b/backend/tests/test_backend_contract.py
@@ -1392,12 +1392,12 @@ def test_llm_moderation_config_requires_global_and_type_enablement(tmp_path: Pat
     assert loaded.llm_moderation.review_all_model_rejects is True
     assert loaded.llm_moderation.max_attempts == 2
     assert loaded.llm_moderation.timeout_seconds == 10.0
-    assert loaded.llm_moderation.max_tokens == 256
+    assert loaded.llm_moderation.max_tokens == 10240
     assert loaded.llm_moderation.initial_backoff_seconds == 1.0
     assert loaded.llm_moderation.raw_retention_enabled is False
     assert loaded.llm_moderation.raw_retention_seconds == 0
     assert enabled_policy.timeout_seconds == 10.0
-    assert enabled_policy.max_tokens == 256
+    assert enabled_policy.max_tokens == 10240
     assert enabled_policy.initial_backoff_seconds == 1.0
 
     monkeypatch.delenv("AQBOX_TEST_LLM_KEY")
@@ -1611,7 +1611,7 @@ def test_ops_config_redacts_llm_api_keys_from_env_and_config(tmp_path: Path, mon
     assert cfg.status_code == 200
     assert cfg.json()["llm_filter"]["api_key_configured"] is True
     assert cfg.json()["llm_filter"]["timeout_seconds"] == 10.0
-    assert cfg.json()["llm_filter"]["max_tokens"] == 256
+    assert cfg.json()["llm_filter"]["max_tokens"] == 10240
     assert cfg.json()["llm_filter"]["initial_backoff_seconds"] == 1.0
     assert cfg.json()["llm_filter"]["raw_retention_enabled"] is False
     assert cfg.json()["llm_filter"]["raw_retention_seconds"] == 0

--- a/frontend/e2e/owner-smoke.cjs
+++ b/frontend/e2e/owner-smoke.cjs
@@ -18,6 +18,7 @@ const geoIp = process.env.AQBOX_E2E_GEO_IP || "";
 const geoAddr = process.env.AQBOX_E2E_GEO_ADDR || "";
 const geoIsp = process.env.AQBOX_E2E_GEO_ISP || "";
 const runDeepSeekSmoke = process.env.AQBOX_E2E_RUN_DEEPSEEK === "1";
+const liveProjectorScreenshotDir = "/tmp/aqbox-live-projector-screenshots";
 
 function loadConfig() {
   let text;
@@ -362,6 +363,32 @@ async function assertAllRegionsLocationDefault(page, surface) {
   if (selectedLocation !== "") {
     throw new Error(`${surface} location filter defaulted to a concrete location: ${selectedLocation}`);
   }
+}
+
+async function projectedTextLocator(projectorPage, text) {
+  return projectorPage.locator(".live-projector-text p").filter({ hasText: text }).first();
+}
+
+async function projectedTextMetrics(projectorText) {
+  return projectorText.evaluate((element) => ({
+    className: element.className,
+    fontSize: Number.parseFloat(getComputedStyle(element).fontSize),
+  }));
+}
+
+async function waitForProjectedFont(projectorText, predicate, label) {
+  const deadline = Date.now() + 10_000;
+  let lastMetrics;
+  while (Date.now() < deadline) {
+    lastMetrics = await projectedTextMetrics(projectorText);
+    if (predicate(lastMetrics)) return lastMetrics;
+    await sleep(100);
+  }
+  throw new Error(`${label} did not update projector font: ${JSON.stringify(lastMetrics)}`);
+}
+
+async function ensureLiveProjectorScreenshotDir() {
+  fs.mkdirSync(liveProjectorScreenshotDir, { recursive: true });
 }
 
 async function selectQuestionType(page, type) {
@@ -758,8 +785,67 @@ async function main() {
     await gotoWithQuestionTypeStorage(page, `${baseUrl}/#/owner/${owner}/live?token=${ownerToken}`, type);
     await assertAllRegionsLocationDefault(page, "Live view");
     await page.getByText(liveText).waitFor({ timeout: 10_000 });
+    await ensureLiveProjectorScreenshotDir();
+    await page.screenshot({
+      path: path.join(liveProjectorScreenshotDir, "live-dashboard-full-width.png"),
+      fullPage: true,
+    });
+
+    const [projectorPage] = await Promise.all([
+      page.waitForEvent("popup"),
+      page.getByRole("button", { name: "打开投屏窗口" }).click(),
+    ]);
+    await projectorPage.waitForLoadState("domcontentloaded");
     await page.locator(".card.shadow-sm.my-2").filter({ hasText: liveText }).first().getByText("← 投屏").click();
-    await page.locator("#textProjectArea").getByText(liveText).waitFor({ timeout: 10_000 });
+
+    const oldProjectArea = page.locator("#textProjectArea");
+    if ((await oldProjectArea.count()) > 0 && (await oldProjectArea.getByText(liveText).count()) > 0) {
+      throw new Error("Live projection rendered in legacy #textProjectArea instead of projector popup");
+    }
+
+    const projectorText = await projectedTextLocator(projectorPage, liveText);
+    await projectorText.waitFor({ timeout: 10_000 });
+    const staleProjectorPage = await context.newPage();
+    await staleProjectorPage.goto(`${baseUrl}/#/owner/${owner}/live/projector`);
+    const staleProjectorText = await projectedTextLocator(staleProjectorPage, liveText);
+    if ((await staleProjectorText.count()) > 0) {
+      throw new Error("Direct projector route displayed stale projection without a session");
+    }
+    await staleProjectorPage.close();
+    await projectorPage.screenshot({
+      path: path.join(liveProjectorScreenshotDir, "projector-clean-after-projection.png"),
+      fullPage: true,
+    });
+
+    await page.getByRole("button", { name: "重置" }).click();
+    const resetMetrics = await waitForProjectedFont(
+      projectorText,
+      (metrics) => metrics.className.split(/\s+/).includes("fs-5"),
+      "Reset"
+    );
+    await page.getByRole("button", { name: "放大" }).click();
+    await waitForProjectedFont(
+      projectorText,
+      (metrics) => metrics.fontSize > resetMetrics.fontSize,
+      "Enlarge"
+    );
+    await page.getByRole("button", { name: "重置" }).click();
+    await waitForProjectedFont(
+      projectorText,
+      (metrics) =>
+        metrics.className.split(/\s+/).includes("fs-5") &&
+        Math.abs(metrics.fontSize - resetMetrics.fontSize) < 0.5,
+      "Second reset"
+    );
+
+    await page.getByRole("button", { name: "清空投屏" }).click();
+    await projectorText.waitFor({ state: "detached", timeout: 10_000 });
+    const projectionStateAfterClear = await page.evaluate(() =>
+      localStorage.getItem("aqbox_live_projection_state")
+    );
+    if (projectionStateAfterClear !== null) {
+      throw new Error("Clear projection did not remove localStorage projection state");
+    }
 
     await page.goto(`${baseUrl}/#/question?token=${liveToken}`);
     await page.getByText("直播中回应").waitFor({ timeout: 10_000 });

--- a/frontend/src/components/LiveProjectorView.vue
+++ b/frontend/src/components/LiveProjectorView.vue
@@ -1,0 +1,151 @@
+<template>
+  <main class="live-projector-surface">
+    <section v-if="visibleState" class="live-projector-content">
+      <div v-if="visibleState.images.length > 0" class="live-projector-images">
+        <img
+          v-for="(image, index) in visibleState.images"
+          :key="imageKey(image, index)"
+          :src="imageSrc(image)"
+          alt=""
+          class="live-projector-image"
+        />
+      </div>
+      <div
+        v-if="visibleState.text"
+        class="live-projector-text text-start fw-bold"
+      >
+        <p
+          v-for="(sentence, index) in formatText(visibleState.text)"
+          :key="index"
+          :class="fsClass"
+        >
+          <strong>{{ sentence }}</strong>
+        </p>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script>
+import {
+  DEFAULT_FONT_SIZE_IDX,
+  FONT_SIZES,
+  readProjectionState,
+  subscribeProjectionState,
+} from "../liveProjectionState";
+
+function clampFontSizeIdx(fontSizeIdx) {
+  if (!Number.isInteger(fontSizeIdx)) {
+    return DEFAULT_FONT_SIZE_IDX;
+  }
+  return Math.min(Math.max(fontSizeIdx, 0), FONT_SIZES.length - 1);
+}
+
+export default {
+  name: "LiveProjectorView",
+  props: {
+    owner: String,
+  },
+  methods: {
+    imageKey(image, index) {
+      if (typeof image === "string") {
+        return image;
+      }
+      return image?.order || image?.url || index;
+    },
+    imageSrc(image) {
+      if (typeof image === "string") {
+        return image;
+      }
+      return image?.url || "";
+    },
+  },
+  computed: {
+    visibleState() {
+      if (
+        !this.projectionState ||
+        this.projectionState.owner !== this.owner ||
+        this.projectionState.sessionId !== this.sessionId ||
+        (!this.projectionState.text && this.projectionState.images.length === 0)
+      ) {
+        return null;
+      }
+      return this.projectionState;
+    },
+    fsClass() {
+      return FONT_SIZES[clampFontSizeIdx(this.visibleState?.fontSizeIdx)];
+    },
+    sessionId() {
+      const session = this.$route.query.session;
+      return typeof session === "string" ? session : "";
+    },
+    formatText() {
+      return (text) => {
+        if (text !== null) {
+          return text.split(/(?:\r\n|\r|\n)/g);
+        }
+        return [];
+      };
+    },
+  },
+  mounted() {
+    this.projectionState = readProjectionState();
+    this.unsubscribeProjectionState = subscribeProjectionState((state) => {
+      this.projectionState = state;
+    });
+  },
+  beforeUnmount() {
+    this.unsubscribeProjectionState();
+  },
+  data() {
+    return {
+      projectionState: null,
+      unsubscribeProjectionState: () => {},
+    };
+  },
+};
+</script>
+
+<style scoped>
+.live-projector-surface {
+  min-height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  background: transparent;
+}
+
+.live-projector-content {
+  min-height: 100vh;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 2rem;
+  padding: 4vh 5vw;
+}
+
+.live-projector-images {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  max-height: 48vh;
+}
+
+.live-projector-image {
+  max-width: 90vw;
+  max-height: 48vh;
+  object-fit: contain;
+}
+
+.live-projector-text {
+  width: 100%;
+  overflow-wrap: anywhere;
+  line-break: anywhere;
+}
+
+.live-projector-text p {
+  margin-bottom: 1rem;
+}
+</style>

--- a/frontend/src/components/LiveView.vue
+++ b/frontend/src/components/LiveView.vue
@@ -2,107 +2,61 @@
   <div>
     <Header :hideHomepageBtn="true"></Header>
     <div class="container-fluid">
-      <div class="row flex-nowrap">
-        <div class="col">
-          <div
-            ref="imageProjectArea"
-            id="imageProjectArea"
-            class="my-4 mx-5 shadow"
-            style="
-              max-width: 45vw;
-              max-height: 70vh;
-              overflow: hidden;
-              resize: both;
-            "
-            :style="{
-              height: projectAreaSize.displayed.imageHeight,
-              width: projectAreaSize.displayed.imageWidth,
-            }"
-          >
-            <viewer
-              :images="images"
-              :options="{
-                inline: true,
-                button: false,
-                fullscreen: false,
-                backdrop: false,
-                title: false,
-                navbar: false,
-                zoomRatio: 0.5,
-              }"
-            >
-              <img
-                v-for="img in images"
-                :key="img.order"
-                :src="img.url"
-                class="img-fluid visually-hidden"
-              />
-            </viewer>
-          </div>
-          <div
-            ref="textProjectArea"
-            id="textProjectArea"
-            class="card shadow my-4 mx-5 border border-dark"
-            style="
-              max-width: 45vw;
-              max-height: 70vh;
-              overflow: auto;
-              resize: both;
-            "
-            :style="{
-              height: projectAreaSize.displayed.textHeight,
-              width: projectAreaSize.displayed.textWidth,
-            }"
-          >
-            <div class="card-body overflow-auto">
-              <p
-                v-for="(sentence, i) in formatText(projected_text)"
-                v-bind:key="i"
-                :class="fsClass"
-                class="text-start fw-bold"
-              >
-                <strong>{{ sentence }}</strong>
-              </p>
-            </div>
-          </div>
-          <nav class="mx-4">
+      <div class="row">
+        <div class="col-12">
+          <nav class="projection-toolbar sticky-top py-2">
             <div class="container-fluid">
-              <ul class="nav justify-content-start">
-                <li class="nav-item mx-1 my-1">文字大小调节</li>
-                <li class="nav-item mx-1">
+              <ul class="nav align-items-center">
+                <li class="nav-item mx-1 my-1">
                   <button
                     type="button"
-                    class="btn btn-sm btn-primary col-sm-12"
+                    class="btn btn-sm btn-primary"
+                    v-on:click="openProjectorWindow()"
+                  >
+                    打开投屏窗口
+                  </button>
+                </li>
+                <li class="nav-item mx-1 my-1">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-primary"
                     :disabled="shrinkBtnDisabled"
                     v-on:click="onFontResizeClick(false)"
                   >
                     缩小
                   </button>
                 </li>
-                <li class="nav-item mx-1">
+                <li class="nav-item mx-1 my-1">
                   <button
                     type="button"
                     :disabled="enlargeBtnDisabled"
-                    class="btn btn-sm btn-primary col-sm-12"
+                    class="btn btn-sm btn-primary"
                     v-on:click="onFontResizeClick(true)"
                   >
                     放大
                   </button>
                 </li>
-                <li class="nav-item mx-1">
+                <li class="nav-item mx-1 my-1">
                   <button
                     type="button"
-                    class="btn btn-sm btn-primary col-sm-12"
+                    class="btn btn-sm btn-primary"
                     v-on:click="onFontSizeResetClick()"
                   >
                     重置
                   </button>
                 </li>
+                <li class="nav-item mx-1 my-1">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-danger"
+                    v-on:click="clearProjection()"
+                  >
+                    清空投屏
+                  </button>
+                </li>
               </ul>
             </div>
           </nav>
-        </div>
-        <div class="col" style="max-width: 48.5vw">
           <div class="container mt-4">
             <nav
               class="my-2 navbar navbar-expand-lg navbar-light"
@@ -115,7 +69,7 @@
                       class="form-select"
                       aria-label="Default select example"
                       id="question_type"
-                      v-on:change="onQueryChange(true, true, true)"
+                      v-on:change="onQueryChange(true, true)"
                       v-model="queryParams['type']"
                     >
                       <option
@@ -245,10 +199,10 @@
               </div>
             </nav>
           </div>
-          <div class="container overflow-auto" style="max-height: 80vh">
+          <div class="container-fluid overflow-auto" style="max-height: 80vh">
             <div class="card shadow-sm my-2" v-for="(q, i) in rows" :key="i">
               <div class="card-body">
-                <div class="container">
+                <div class="container-fluid">
                   <div class="row">
                     <div class="col-12 col-sm-3">
                       <div class="list-group">
@@ -381,7 +335,15 @@
 import Header from "./Header.vue";
 import Pagination from "v-pagination-3";
 import ImageDisplay from "./ImageDisplay.vue";
+import {
+  DEFAULT_FONT_SIZE_IDX,
+  FONT_SIZES,
+  clearProjectionState,
+  readProjectionState,
+  writeProjectionState,
+} from "../liveProjectionState";
 const storagePrefix = "ownerView_";
+const projectionSessionStoragePrefix = "liveProjectionSession_";
 // Location options are per owner/type and can be empty for historical rows, so never persist them across boxes.
 const transientQueryParamKeys = new Set(["ip_addr"]);
 const orderDirection = [
@@ -391,10 +353,15 @@ const orderDirection = [
   { by: "word_count", reversed: false },
 ];
 
-const fontSizes = ["fs-6", "fs-5", "fs-4", "fs-3", "fs-2", "fs-1"];
-const defaultFontSizeIdx = 1;
 const queryDebounceMs = 200;
-var currentFontSizeIdx = defaultFontSizeIdx;
+var currentFontSizeIdx = DEFAULT_FONT_SIZE_IDX;
+
+function createProjectionSessionId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
 
 export default {
   name: "LiveView",
@@ -407,20 +374,51 @@ export default {
     owner: String,
   },
   methods: {
-    applyProjectAreaSize() {
-      this.projectAreaSize.displayed.imageHeight =
-        this.projectAreaSize.saved.imageHeight;
-      this.projectAreaSize.displayed.imageWidth =
-        this.projectAreaSize.saved.imageWidth;
-      this.projectAreaSize.displayed.textHeight =
-        this.projectAreaSize.saved.textHeight;
-      this.projectAreaSize.displayed.textWidth =
-        this.projectAreaSize.saved.textWidth;
+    writeCurrentProjection(text, images) {
+      writeProjectionState({
+        owner: this.owner,
+        sessionId: this.projectionSessionId,
+        text,
+        images,
+        fontSizeIdx: currentFontSizeIdx,
+        updatedAt: new Date().toISOString(),
+      });
+    },
+    syncProjectionFontSize() {
+      const existingState = readProjectionState();
+      if (
+        existingState?.owner !== this.owner ||
+        existingState.sessionId !== this.projectionSessionId
+      ) {
+        return;
+      }
+
+      writeProjectionState({
+        ...existingState,
+        fontSizeIdx: currentFontSizeIdx,
+        updatedAt: new Date().toISOString(),
+      });
+    },
+    openProjectorWindow() {
+      const route = this.$router.resolve({
+        name: "live-projector",
+        params: { owner: this.owner },
+        query: { session: this.projectionSessionId },
+      });
+      const projectorWindow = window.open(
+        route.href,
+        "aqbox-live-projector",
+        "popup=yes,width=600,height=400,location=no,toolbar=no,menubar=no,status=no"
+      );
+      if (!projectorWindow) {
+        alert("投屏窗口被浏览器拦截了，请允许此网站弹出窗口后重试。");
+      }
+    },
+    clearProjection() {
+      clearProjectionState();
     },
     projectQuestion(uuid, text, images, answered_at) {
-      this.projected_text = text;
-      this.images = images;
-      this.applyProjectAreaSize();
+      this.writeCurrentProjection(text, images);
       // automatically answer the question if it was not answered before
       let time = Date.parse(answered_at);
       const autoReply = `已于 ${new Date().toLocaleString("zh-CN", {
@@ -449,11 +447,11 @@ export default {
           });
       }
     },
-    onQueryChange(resetPage, needRetry = false, init = false, debounce = true) {
+    onQueryChange(resetPage, needRetry = false, debounce = true) {
       if (debounce) {
         clearTimeout(this.queryDebounceTimer);
         this.queryDebounceTimer = setTimeout(
-          () => this.onQueryChange(resetPage, needRetry, init, false),
+          () => this.onQueryChange(resetPage, needRetry, false),
           queryDebounceMs
         );
         return;
@@ -487,26 +485,6 @@ export default {
           this.rows = resp.data.questions;
           this.total_count = resp.data.total;
           this.locationOptions = resp.data.location_options || [];
-          this.withImages =
-            this.ownerProfiles[this.owner].question_types[
-              this.queryParams["type"]
-            ].support_image;
-          if (init) {
-            this.projected_text = "";
-            this.images = [];
-            if (this.withImages) {
-              this.projectAreaSize.saved.imageHeight = "350px";
-              this.projectAreaSize.saved.imageWidth = "600px";
-              this.projectAreaSize.saved.textHeight = "200px";
-              this.projectAreaSize.saved.textWidth = "600px";
-            } else {
-              this.projectAreaSize.saved.imageHeight = "0px";
-              this.projectAreaSize.saved.imageWidth = "0px";
-              this.projectAreaSize.saved.textHeight = "400px";
-              this.projectAreaSize.saved.textWidth = "600px";
-            }
-            this.applyProjectAreaSize();
-          }
         })
         .catch((err) => {
           console.log(err.response);
@@ -526,7 +504,7 @@ export default {
                 page_size: 5,
                 page: 1,
               };
-              this.onQueryChange(false, false, false, false);
+              this.onQueryChange(false, false, false);
             } else {
               alert("提问箱好像坏掉了，直接ping管理员吧！");
               this.$router.push("/");
@@ -558,7 +536,7 @@ export default {
           }
         )
         .then(() => {
-          this.onQueryChange(true, false, false, false);
+          this.onQueryChange(true, false, false);
         })
         .catch((err) => {
           console.log(err.response);
@@ -582,7 +560,7 @@ export default {
         })
         .then(() => {
           this.cancelDelete();
-          this.onQueryChange(false, false, false, false);
+          this.onQueryChange(false, false, false);
         })
         .catch((err) => {
           console.log(err);
@@ -606,27 +584,23 @@ export default {
     },
     onFontResizeClick(enlarge) {
       if (enlarge) {
-        if (currentFontSizeIdx < fontSizes.length - 1) {
-          this.fsClass = fontSizes[++currentFontSizeIdx];
+        if (currentFontSizeIdx < FONT_SIZES.length - 1) {
+          currentFontSizeIdx += 1;
         }
       } else {
         if (currentFontSizeIdx > 0) {
-          this.fsClass = fontSizes[--currentFontSizeIdx];
+          currentFontSizeIdx -= 1;
         }
       }
       this.shrinkBtnDisabled = currentFontSizeIdx <= 0;
-      this.enlargeBtnDisabled = currentFontSizeIdx >= fontSizes.length - 1;
-      console.log(
-        currentFontSizeIdx,
-        this.shrinkBtnDisabled,
-        this.enlargeBtnDisabled
-      );
+      this.enlargeBtnDisabled = currentFontSizeIdx >= FONT_SIZES.length - 1;
+      this.syncProjectionFontSize();
     },
     onFontSizeResetClick() {
-      currentFontSizeIdx = defaultFontSizeIdx;
-      this.fsClass = fontSizes[currentFontSizeIdx];
-      this.shrinkBtnDisabled = false;
-      this.enlargeBtnDisabled = false;
+      currentFontSizeIdx = DEFAULT_FONT_SIZE_IDX;
+      this.shrinkBtnDisabled = currentFontSizeIdx <= 0;
+      this.enlargeBtnDisabled = currentFontSizeIdx >= FONT_SIZES.length - 1;
+      this.syncProjectionFontSize();
     },
   },
   computed: {
@@ -654,6 +628,33 @@ export default {
     },
   },
   beforeMount() {
+    const projectionSessionStorageKey =
+      projectionSessionStoragePrefix + this.owner;
+    this.projectionSessionId =
+      sessionStorage.getItem(projectionSessionStorageKey) ||
+      createProjectionSessionId();
+    sessionStorage.setItem(
+      projectionSessionStorageKey,
+      this.projectionSessionId
+    );
+
+    currentFontSizeIdx = DEFAULT_FONT_SIZE_IDX;
+    this.shrinkBtnDisabled = currentFontSizeIdx <= 0;
+    this.enlargeBtnDisabled = currentFontSizeIdx >= FONT_SIZES.length - 1;
+
+    const existingState = readProjectionState();
+    if (
+      existingState?.owner === this.owner &&
+      existingState.sessionId === this.projectionSessionId &&
+      Number.isInteger(existingState.fontSizeIdx)
+    ) {
+      currentFontSizeIdx = Math.min(
+        Math.max(existingState.fontSizeIdx, 0),
+        FONT_SIZES.length - 1
+      );
+      this.shrinkBtnDisabled = currentFontSizeIdx <= 0;
+      this.enlargeBtnDisabled = currentFontSizeIdx >= FONT_SIZES.length - 1;
+    }
     this.navbarStyling = {
       "background-color": this.ownerProfiles[this.owner].colors.primary_color,
     };
@@ -671,29 +672,7 @@ export default {
         }
       }
     }
-    this.onQueryChange(true, true, true, false);
-  },
-  async mounted() {
-    const ob = new ResizeObserver((entries) => {
-      for (let entry of entries) {
-        const cr = entry.contentRect;
-        switch (entry.target.id) {
-          case "imageProjectArea":
-            this.projectAreaSize.saved.imageHeight = `${Math.round(
-              cr.height
-            )}px`;
-            this.projectAreaSize.saved.imageWidth = `${Math.round(cr.width)}px`;
-            break;
-          case "textProjectArea":
-            // +2 抵消 line height
-            this.projectAreaSize.saved.textHeight = `${cr.height + 2}px`;
-            this.projectAreaSize.saved.textWidth = `${cr.width + 2}px`;
-        }
-      }
-    });
-
-    ob.observe(this.$refs.textProjectArea);
-    ob.observe(this.$refs.imageProjectArea);
+    this.onQueryChange(true, true, false);
   },
   beforeUnmount() {
     clearTimeout(this.queryDebounceTimer);
@@ -709,33 +688,15 @@ export default {
         page_size: 5,
         page: 1,
       },
-      withImages: false,
       toDelete: "",
       rows: [],
       locationOptions: [],
       total_count: 0,
       queryDebounceTimer: null,
       navbarStyling: {},
-      images: [],
-      projected_text: "",
-      fsClass: fontSizes[defaultFontSizeIdx],
+      projectionSessionId: "",
       enlargeBtnDisabled: false,
       shrinkBtnDisabled: false,
-      projectAreaSize: {
-        displayed: {
-          textHeight: "",
-          textWidth: "",
-          imageHeight: "",
-          imageWidth: "",
-        },
-        saved: {
-          textHeight: "",
-          textWidth: "",
-          imageHeight: "",
-          imageWidth: "",
-        },
-        selector: 0,
-      },
       markedOnly: false,
     };
   },
@@ -750,5 +711,11 @@ export default {
 
 #site-header {
   max-height: 5vh;
+}
+
+.projection-toolbar {
+  z-index: 1020;
+  background: var(--bs-body-bg);
+  border-bottom: 1px solid var(--bs-border-color);
 }
 </style>

--- a/frontend/src/liveProjectionState.js
+++ b/frontend/src/liveProjectionState.js
@@ -1,0 +1,161 @@
+export const LIVE_PROJECTION_STATE_KEY = "aqbox_live_projection_state";
+export const FONT_SIZES = ["fs-6", "fs-5", "fs-4", "fs-3", "fs-2", "fs-1"];
+export const DEFAULT_FONT_SIZE_IDX = 1;
+
+const localEventName = "aqbox-live-projection-state";
+
+function getWindow() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window;
+}
+
+function getStorage() {
+  const currentWindow = getWindow();
+  if (!currentWindow) {
+    return null;
+  }
+
+  try {
+    return currentWindow.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeImages(images) {
+  return Array.isArray(images) ? images : [];
+}
+
+function normalizeFontSizeIdx(fontSizeIdx) {
+  return Number.isInteger(fontSizeIdx) ? fontSizeIdx : DEFAULT_FONT_SIZE_IDX;
+}
+
+function normalizeUpdatedAt(updatedAt) {
+  return typeof updatedAt === "string" ? updatedAt : new Date().toISOString();
+}
+
+function normalizeState(state) {
+  if (!state || typeof state !== "object") {
+    return null;
+  }
+
+  return {
+    owner: typeof state.owner === "string" ? state.owner : "",
+    sessionId: typeof state.sessionId === "string" ? state.sessionId : "",
+    text: typeof state.text === "string" ? state.text : "",
+    images: normalizeImages(state.images),
+    fontSizeIdx: normalizeFontSizeIdx(state.fontSizeIdx),
+    updatedAt: normalizeUpdatedAt(state.updatedAt),
+  };
+}
+
+function dispatchLocalChange(state) {
+  const currentWindow = getWindow();
+  if (!currentWindow || typeof currentWindow.CustomEvent !== "function") {
+    return;
+  }
+
+  currentWindow.dispatchEvent(
+    new currentWindow.CustomEvent(localEventName, {
+      detail: state,
+    })
+  );
+}
+
+export function readProjectionState() {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  let rawState;
+  try {
+    rawState = storage.getItem(LIVE_PROJECTION_STATE_KEY);
+  } catch {
+    return null;
+  }
+
+  if (!rawState) {
+    return null;
+  }
+
+  try {
+    return normalizeState(JSON.parse(rawState));
+  } catch {
+    return null;
+  }
+}
+
+export function writeProjectionState(state) {
+  const normalizedState = normalizeState({
+    ...state,
+    updatedAt: state?.updatedAt || new Date().toISOString(),
+  });
+
+  if (!normalizedState) {
+    return null;
+  }
+
+  const storage = getStorage();
+  if (!storage) {
+    return normalizedState;
+  }
+
+  try {
+    storage.setItem(
+      LIVE_PROJECTION_STATE_KEY,
+      JSON.stringify(normalizedState)
+    );
+  } catch {
+    return normalizedState;
+  }
+
+  dispatchLocalChange(normalizedState);
+  return normalizedState;
+}
+
+export function clearProjectionState() {
+  const storage = getStorage();
+  if (storage) {
+    try {
+      storage.removeItem(LIVE_PROJECTION_STATE_KEY);
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }
+
+  dispatchLocalChange(null);
+}
+
+export function subscribeProjectionState(callback) {
+  const currentWindow = getWindow();
+  if (!currentWindow || typeof callback !== "function") {
+    return () => {};
+  }
+
+  const onStorage = (event) => {
+    if (event.key !== LIVE_PROJECTION_STATE_KEY) {
+      return;
+    }
+    callback(readProjectionState());
+  };
+
+  const onLocalChange = (event) => {
+    callback(event.detail || null);
+  };
+
+  currentWindow.addEventListener("storage", onStorage);
+  currentWindow.addEventListener(localEventName, onLocalChange);
+
+  return () => {
+    currentWindow.removeEventListener("storage", onStorage);
+    currentWindow.removeEventListener(localEventName, onLocalChange);
+  };
+}
+
+export const read = readProjectionState;
+export const write = writeProjectionState;
+export const clear = clearProjectionState;
+export const subscribe = subscribeProjectionState;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -14,6 +14,7 @@ import QuestionNew from "./components/QuestionNew.vue";
 import QuestionView from "./components/QuestionView.vue";
 import AnswerView from "./components/AnswerView.vue";
 import LiveView from "./components/LiveView.vue";
+import LiveProjectorView from "./components/LiveProjectorView.vue";
 import Main from "./components/Main.vue";
 
 const routes = [
@@ -28,6 +29,12 @@ const routes = [
     name: "live",
     path: "/owner/:owner/live",
     component: LiveView,
+    props: true,
+  },
+  {
+    name: "live-projector",
+    path: "/owner/:owner/live/projector",
+    component: LiveProjectorView,
     props: true,
   },
   { name: "question", path: "/question", component: QuestionView, props: true },
@@ -51,7 +58,33 @@ const router = createRouter({
   routes,
 });
 
+function mountApp(profileProvider = null) {
+  const app = createApp(App);
+  app.config.globalProperties.$scrollToTop = () => window.scrollTo(0, 0);
+  app.use(VueAxios, axios);
+  app.use(router);
+  app.use(VueViewer);
+  if (profileProvider) {
+    app.mixin(profileProvider);
+  }
+  app.mount("#app");
+}
+
+function isInitialProjectorRoute() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return /^#\/owner\/[^/?#]+\/live\/projector(?:[?#].*)?$/.test(
+    window.location.hash
+  );
+}
+
 (async () => {
+  if (isInitialProjectorRoute()) {
+    mountApp();
+    return;
+  }
+
   await axios
     .get("/api/profiles")
     .then((resp) => {
@@ -66,13 +99,7 @@ const router = createRouter({
           };
         },
       };
-      const app = createApp(App);
-      app.config.globalProperties.$scrollToTop = () => window.scrollTo(0, 0);
-      app.use(VueAxios, axios);
-      app.use(router);
-      app.use(VueViewer);
-      app.mixin(profileProvider);
-      app.mount("#app");
+      mountApp(profileProvider);
     })
     .catch((err) => {
       console.log(err.response);


### PR DESCRIPTION
## Summary
- Replace embedded live projection area with a separate projector popup window
- Add browser-local projection state sync plus a clean projector route
- Expand live question list and move projection controls into a sticky toolbar
- Update smoke coverage and AGENTS Playwright guidance

## Verification
- node --check frontend/e2e/owner-smoke.cjs
- cd frontend && npm run lint -- --max-warnings=0
- cd frontend && npm run build
- cd frontend && AQBOX_E2E_CONFIG=../backend/config/config.local.yaml npm run e2e:smoke (passed before the final popup default was adjusted to 600x400)