### PR TITLE
[codex] fix mark button list refresh

### DIFF
--- a/frontend/e2e/owner-smoke.cjs
+++ b/frontend/e2e/owner-smoke.cjs
@@ -317,6 +317,31 @@ async function waitForOwnerList(page) {
   );
 }
 
+async function markWithoutReloadingOwnerList(page, card) {
+  let ownerListRequestCount = 0;
+  const countOwnerListRequest = (request) => {
+    if (request.url().includes("/api/owner/questions") && request.method() === "POST") {
+      ownerListRequestCount += 1;
+    }
+  };
+  page.on("request", countOwnerListRequest);
+  try {
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes("/mark") && resp.request().method() === "PUT",
+        { timeout: 10_000 }
+      ),
+      card.getByText("标记", { exact: true }).first().click(),
+    ]);
+    await card.getByText("取消标记", { exact: true }).first().waitFor({ timeout: 10_000 });
+    if (ownerListRequestCount !== 0) {
+      throw new Error(`Marking a question reloaded the owner list ${ownerListRequestCount} time(s)`);
+    }
+  } finally {
+    page.off("request", countOwnerListRequest);
+  }
+}
+
 async function gotoWithClearedStorage(page, url) {
   await page.goto(baseUrl);
   await page.evaluate(() => localStorage.clear());
@@ -757,7 +782,7 @@ async function main() {
     await page.getByText(unique).waitFor({ timeout: 10_000 });
 
     const card = page.locator(".card.shadow-lg.m-3").filter({ hasText: unique }).first();
-    await Promise.all([waitForOwnerList(page), card.getByText("标记", { exact: true }).first().click()]);
+    await markWithoutReloadingOwnerList(page, card);
     await Promise.all([waitForOwnerList(page), page.getByText("只显示已标记").click()]);
     await page.getByText(unique).waitFor({ timeout: 10_000 });
     await Promise.all([waitForOwnerList(page), page.getByText("显示全部").click()]);
@@ -785,6 +810,8 @@ async function main() {
     await gotoWithQuestionTypeStorage(page, `${baseUrl}/#/owner/${owner}/live?token=${ownerToken}`, type);
     await assertAllRegionsLocationDefault(page, "Live view");
     await page.getByText(liveText).waitFor({ timeout: 10_000 });
+    const liveCard = page.locator(".card.shadow-sm.my-2").filter({ hasText: liveText }).first();
+    await markWithoutReloadingOwnerList(page, liveCard);
     await ensureLiveProjectorScreenshotDir();
     await page.screenshot({
       path: path.join(liveProjectorScreenshotDir, "live-dashboard-full-width.png"),

--- a/frontend/src/components/LiveView.vue
+++ b/frontend/src/components/LiveView.vue
@@ -523,20 +523,25 @@ export default {
       }
     },
     markQuestion(q) {
+      const mark = !q.marked;
       this.axios
         .put(
           "/api/owner/questions/" + q.uuid + "/mark",
           {
             owner: q.owner,
             type: q.type,
-            mark: !q.marked,
+            mark,
           },
           {
             headers: { Authorization: `Bearer ${this.$route.query.token}` },
           }
         )
         .then(() => {
-          this.onQueryChange(true, false, false);
+          q.marked = mark;
+          if (this.markedOnly && !mark) {
+            this.rows = this.rows.filter((row) => row.uuid !== q.uuid);
+            this.total_count = Math.max(0, this.total_count - 1);
+          }
         })
         .catch((err) => {
           console.log(err.response);

--- a/frontend/src/components/OwnerView.vue
+++ b/frontend/src/components/OwnerView.vue
@@ -565,20 +565,25 @@ export default {
       this.onQueryChange(true, false, false);
     },
     markQuestion(q) {
+      const mark = !q.marked;
       this.axios
         .put(
           "/api/owner/questions/" + q.uuid + "/mark",
           {
             owner: q.owner,
             type: q.type,
-            mark: !q.marked,
+            mark,
           },
           {
             headers: { Authorization: `Bearer ${this.$route.query.token}` },
           }
         )
         .then(() => {
-          this.onQueryChange(true, false, false);
+          q.marked = mark;
+          if (this.markedOnly && !mark) {
+            this.rows = this.rows.filter((row) => row.uuid !== q.uuid);
+            this.total_count = Math.max(0, this.total_count - 1);
+          }
         })
         .catch((err) => {
           console.log(err.response);


### PR DESCRIPTION
## Summary

- update mark state locally in the owner dashboard and live view
- avoid re-fetching the full owner list and resetting pagination after marking
- remove a card locally when unmarking while the marked-only filter is active
- add smoke coverage that rejects any owner-list reload after a mark action

## Root cause

The successful mark callback called `onQueryChange(true, false, false)`. That issued another `POST /api/owner/questions` and reset the current page to page 1, which appeared as an unexpected UI refresh.

## Impact

Mark and unmark actions now update the affected card immediately without navigating, reloading the list, or resetting pagination.

## Validation

- `AQBOX_E2E_CONFIG=../backend/config/config.local.yaml npm run e2e:smoke`
- `npm run lint -- --max-warnings=0`
- `npm run build`
- browser verification confirmed the fixed interaction sends only `PUT /mark`, keeps the URL unchanged, and updates the button state immediately